### PR TITLE
Migrate to CodeClimate Action for unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,15 +22,10 @@ jobs:
       with:
         path: /home/runner/go/pkg/mod
         key: go-mod-test
-    - name: Download codeclimate reporter
-      run: wget -O cc-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 && chmod +x cc-reporter
-    - name: Prepare code coverage
-      run: ./cc-reporter before-build
-    - name: Run unit tests
-      run: go test -coverprofile=c.out ./...
-    - name: Format code coverage
-      run: ./cc-reporter format-coverage c.out -t gocov -p $(basename $PWD)
-    - name: Upload code coverage
+    - name: Test & Publish Code Coverage
+      uses: paambaati/codeclimate-action@v2.5.0
       env:
         CC_TEST_REPORTER_ID: e83a1c47936e887bb37d1e37ebd3395744d4b73693a3c6e199294182be045210
-      run: ./cc-reporter after-build -t gocov -p $(basename $PWD)
+      with:
+        coverageCommand: go test ./... -coverprofile c.out
+        prefix: znapzend-exporter


### PR DESCRIPTION
Due to https://github.com/paambaati/codeclimate-action/issues/109 it was not possible to publish code climate reports for Gocov reports.
With v2.5.0, this is now fixed.