### PR TITLE
Add TargetHost to Pre/Post send metrics

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,8 +55,8 @@ Setup ZnapZend with `znapzendzetup`, so that your config could look like this:
 *** backup plan: tank/data/home ***
            dst_0 = remote-host:backup/data/home
       dst_0_plan = 14days=>1day,60days=>1week,12months=>1month
-    dst_0_precmd = /usr/bin/curl -sS localhost:8080/presend/tank/data/home
-    dst_0_pstcmd = /usr/bin/curl -sS localhost:8080/postsend/tank/data/home?SelfResetAfter=1h
+    dst_0_precmd = /usr/bin/curl -sS localhost:8080/presend/tank/data/home?TargetHost=remote-host
+    dst_0_pstcmd = /usr/bin/curl -sS localhost:8080/postsend/tank/data/home?SelfResetAfter=1h\&TargetHost=remote-host
          enabled = on
          mbuffer = off
     mbuffer_size = 1G
@@ -110,13 +110,18 @@ TIP: By default, each request to a metric endpoint resets the other gauges, exce
 `ResetPreSend`,bool,`true`,Resets pre-snapshot metric to 0. Ineffective for `/presend/*`.
 `ResetPostSend`,bool,`true`,Resets pre-snapshot metric to 0. Ineffective for `/postsend/*`.
 `SelfResetAfter`,https://golang.org/pkg/time/#ParseDuration[Duration],`0s`,Resets metric for itself after given delay.
+`TargetHost`,string,`""`,Sets the `target_host` label with this value. Only effective for `/presend/\*` and `/postsend/*`.
 |===
 
 IMPORTANT: Be sure to give enough time for Prometheus to scrape (and potentially retry) the exporter before resetting the
            metrics for the next snapshot/send window. The time duration depends on the scrape interval.
 
 NOTE: In order specify multiple parameters in the curl commands above, you need to escape the `&` character, e.g.
-      `/usr/bin/curl -sS localhost:8080/postsend/tank/data/home?SelfResetAfter=1h\&ResetPostSnap=false`
+      `/usr/bin/curl -sS localhost:8080/postsend/tank/data/home?SelfResetAfter=1h\&TargetHost=backup.host`
+
+TIP: To register jobs in advance including Pre/Post-Send metrics, specify the remote host after an `@` char e.g.
+     `--jobs.register tank/data/home@host-1 --jobs.register tank/data/home@host-2` (the same source dataset can have
+     multiple target hosts).
 
 == Configuration
 

--- a/go.sum
+++ b/go.sum
@@ -17,7 +17,6 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
-github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -32,8 +31,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
-github.com/gin-gonic/gin v1.6.2 h1:88crIK23zO6TqlQBt+f9FrPJNKm9ZEr7qjp9vl/d5TM=
-github.com/gin-gonic/gin v1.6.2/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.6.3 h1:ahKqKTFpO5KTPHxWZjEdPScmYaGtLo8Y4DMHoEsnp14=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -92,6 +89,7 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -129,8 +127,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
-github.com/prometheus/client_golang v1.5.1 h1:bdHYieyGlH+6OLEk2YQha8THib30KP0/yD0YH9m6xcA=
-github.com/prometheus/client_golang v1.5.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.6.0 h1:YVPodQOcK15POxhgARIvnDRVpLcuK8mglnMrWfyrw6A=
 github.com/prometheus/client_golang v1.6.0/go.mod h1:ZLOG9ck3JLRdB5MgO8f+lLTe83AXG6ro35rLTxvnIl4=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -145,8 +141,6 @@ github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8b
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
-github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
-github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.0.11 h1:DhHlBtkHWPYi8O2y31JkK0TF+DGM+51OopZjH/Ia5qI=
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
@@ -154,8 +148,7 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.5.0 h1:1N5EYkVAPEywqZRJd7cwnRtCb6xJx7NH3T3WUTF980Q=
-github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -172,8 +165,6 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/viper v1.6.2 h1:7aKfF+e8/k68gda3LOjo5RxiUqddoFxVq4BKBPrxk5E=
-github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/spf13/viper v1.6.3 h1:pDDu1OyEDTKzpJwdq4TiuLyMsUgRa/BT5cn5O62NoHs=
 github.com/spf13/viper v1.6.3/go.mod h1:jUMtyi0/lB5yZH/FjyGAoH7IMNrIhlBf6pXZmbMDvzw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -188,7 +179,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
@@ -223,8 +213,6 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/p
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
-golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
 	"os"
+	"strings"
 )
 
 var (
@@ -46,10 +47,15 @@ func main() {
 	}
 
 	for _, job := range cfg.Jobs.Register {
-		if err := RegisterMetric(job); err != nil {
-			log.WithField("label", job).WithError(err).Warn("Failed to register job.")
+		arr := strings.Split(job, "@")
+		j := Job{JobName: arr[0]}
+		if len(arr) >= 2 {
+			j.TargetHost = arr[1]
+		}
+		if err := j.RegisterMetric(); err != nil {
+			log.WithField("job", job).WithError(err).Warn("Failed to register job.")
 		} else {
-			log.WithField("label", job).Info("Registered job.")
+			log.WithField("job", job).Info("Registered job.")
 		}
 	}
 

--- a/metrics.go
+++ b/metrics.go
@@ -23,12 +23,12 @@ var (
 		Namespace: namespace,
 		Name:      "presend_command_started",
 		Help:      "whether the command to run prior zfs send was started",
-	}, []string{"job"})
+	}, []string{"job", "target_host"})
 	postSendMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Name:      "postsend_command_finished",
 		Help:      "whether the command to run after zfs send was finished",
-	}, []string{"job"})
+	}, []string{"job", "target_host"})
 	metricVector = []*prometheus.GaugeVec{preSnapMetric, postSnapMetric, preSendMetric, postSendMetric}
 )
 
@@ -36,12 +36,25 @@ type (
 	// ResetMetricTuple contains a gauge and its enable flag.
 	ResetMetricTuple struct {
 		resetEnabled bool
+		targetHost   string
 		vec          *prometheus.GaugeVec
 	}
 )
 
-func (p *Parameters) setMetric(vec *prometheus.GaugeVec) {
+func (p *Job) setMetric(vec *prometheus.GaugeVec) {
 	gauge := vec.WithLabelValues(p.JobName)
+	p.setValue(gauge)
+}
+
+func (p *Job) setMetricWithHost(vec *prometheus.GaugeVec) {
+	gauge := vec.With(prometheus.Labels{
+		"job":         p.JobName,
+		"target_host": p.TargetHost,
+	})
+	p.setValue(gauge)
+}
+
+func (p *Job) setValue(gauge prometheus.Gauge) {
 	gauge.Set(1)
 	if p.SelfResetAfter > 0 {
 		go func() {
@@ -55,31 +68,41 @@ func (p *Parameters) setMetric(vec *prometheus.GaugeVec) {
 }
 
 // ResetMetrics resets all given gauges to 0 if the flag is set to true.
-func ResetMetrics(label string, tuples ...ResetMetricTuple) {
+func (p *Job) ResetMetrics(tuples ...ResetMetricTuple) {
 	for _, tuple := range tuples[:] {
 		if !tuple.resetEnabled {
 			continue
 		}
-		tuple.vec.WithLabelValues(label).Set(0)
+		if tuple.targetHost == "" {
+			tuple.vec.WithLabelValues(p.JobName).Set(0)
+		} else {
+			tuple.vec.WithLabelValues(p.JobName, tuple.targetHost).Set(0)
+		}
 	}
 }
 
 // RegisterMetric registers 4 new gauges with the given label (preSnap, postSnap, preSend, postSend) and initializes the
 // values with 0.
-func RegisterMetric(label string) error {
-	logEvent := log.WithField("label", label)
-	for _, vec := range metricVector {
-		gauge := vec.WithLabelValues(label)
-		gauge.Set(0)
-		logEvent.WithField("metric", gauge.Desc().String()).Debug("Registered metric.")
+func (p *Job) RegisterMetric() error {
+	logEvent := log.WithField("jobName", p.JobName)
+	preSnapMetric.WithLabelValues(p.JobName).Set(1)
+	postSnapMetric.WithLabelValues(p.JobName).Set(1)
+	if p.TargetHost != "" {
+		preSendMetric.WithLabelValues(p.JobName, p.TargetHost).Set(1)
+		postSendMetric.WithLabelValues(p.JobName, p.TargetHost).Set(1)
 	}
+	logEvent.Debug("Registered metric.")
 	return nil
 }
 
 // UnregisterMetric deletes 4 gauges with the given label, if found.
-func UnregisterMetric(label string) {
+func (p *Job) UnregisterMetric() {
 	for _, vec := range metricVector {
-		vec.DeleteLabelValues(label)
+		if p.TargetHost == "" {
+			vec.DeleteLabelValues(p.JobName)
+		} else {
+			vec.DeleteLabelValues(p.JobName, p.TargetHost)
+		}
 	}
-	log.WithField("label", label).Debug("Unregistered metric.")
+	log.WithField("job", p.JobName).Debug("Unregistered metric.")
 }


### PR DESCRIPTION
The way prometheus labels work in the client we need to make this mandatory to support multiple snapshot receivers. And each receiver can fail independently.